### PR TITLE
Allow the tags file name to be configured

### DIFF
--- a/doc/bundler.txt
+++ b/doc/bundler.txt
@@ -43,6 +43,12 @@ COMMANDS                                        *bundler-commands*
 :Bpedit[!] [gem]        Like |:Bopen|, but use a preview window.  Add ! to
                         suppress the |:lcd|.
 
+CONFIGURATION                                   *bundler-configuration*
+
+To set the name of your tags-file (default: tags) use: >
+
+    let g:bundler_tags_file = "name_of_tags_file"
+<
 ABOUT                                           *bundler-about*
 
 Grab the latest version or report a bug on GitHub:

--- a/plugin/bundler.vim
+++ b/plugin/bundler.vim
@@ -134,6 +134,11 @@ augroup END
 " }}}1
 " Initialization {{{1
 
+" the filename of your 'tags'
+if !exists('g:bundler_tags_file')
+    let g:bundler_tags_file = "tags"
+endif
+
 function! s:FindBundlerRoot(path) abort
   let path = s:shellslash(a:path)
   let fn = fnamemodify(path,':s?[\/]$??')
@@ -406,7 +411,8 @@ function! s:buffer_alter_paths() dict abort
       call insert(new,remove(new,index))
     endif
     let old = type(self.getvar('bundler_paths')) == type([]) ? self.getvar('bundler_paths') : []
-    for [option, suffix] in [['path', 'lib'], ['tags', 'tags']]
+
+    for [option, suffix] in [['path', 'lib'], ["tags", g:bundler_tags_file]]
       let value = self.getvar('&'.option)
       if !empty(old)
         let drop = s:build_path_option(old,suffix)


### PR DESCRIPTION
Hi,

this very small change allows the `tags` file to be configurable via `g:bundler_tags_file`.

I use this to name my tags file `.tags` so I can ignore it when `ack`ing for text.

Thanks for all your vim plugins,
Frank  
