### PR TITLE
Syntax highlight ruby version specification

### DIFF
--- a/plugin/bundler.vim
+++ b/plugin/bundler.vim
@@ -99,7 +99,7 @@ let s:abstract_prototype = {}
 " Syntax highlighting {{{1
 
 function! s:syntaxfile()
-  syntax keyword rubyGemfileMethod gemspec gem source path git group platforms env
+  syntax keyword rubyGemfileMethod gemspec gem source path git group platforms env ruby
   hi def link rubyGemfileMethod Function
 endfunction
 


### PR DESCRIPTION
Bundler 1.2.0pre add ruby to the DSL for specifying the ruby version.

https://github.com/carlhuda/bundler/blob/a63bdd32736ea176dbf6ae68cc54a1f398e557d9/CHANGELOG.md

As of 8/1/2012, this is the only way Heroku will support ruby version specification.
