### PR TITLE
"ruby" directive

### DIFF
--- a/plugin/bundler.vim
+++ b/plugin/bundler.vim
@@ -99,7 +99,7 @@ let s:abstract_prototype = {}
 " Syntax highlighting {{{1
 
 function! s:syntaxfile()
-  syntax keyword rubyGemfileMethod gemspec gem source path git group platforms env
+  syntax keyword rubyGemfileMethod gemspec gem source path git group platforms env ruby
   hi def link rubyGemfileMethod Function
 endfunction
 


### PR DESCRIPTION
It's under development now and will be enabled on bundler 1.2.
But it's actively used to make heroku use 1.9.3.
