### PR TITLE
Extract QuickFixCmdPreMake and QuickFixCmdPostMake and return early for non-Bundler projects

### DIFF
--- a/plugin/bundler.vim
+++ b/plugin/bundler.vim
@@ -472,17 +472,23 @@ endfunction
 
 call s:command("-bar -bang -nargs=? -complete=customlist,s:BundleComplete Bundle :execute s:Bundle('<bang>',<q-args>)")
 
+function! s:IsBundlerProject()
+  return &makeprg =~# '^bundle' && exists('b:bundler_root')
+endfunction
+
 function! s:QuickFixCmdPreMake()
-  if &makeprg =~# '^bundle' && exists('b:bundler_root')
-    call s:push_chdir()
+  if !s:IsBundlerProject()
+    return
   endif
+  call s:push_chdir()
 endfunction
 
 function! s:QuickFixCmdPostMake()
-  if &makeprg =~# '^bundle' && exists('b:bundler_root')
-    call s:pop_command()
-    call s:project().paths('refresh')
+  if !s:IsBundlerProject()
+    return
   endif
+  call s:pop_command()
+  call s:project().paths('refresh')
 endfunction
 
 augroup bundler_make


### PR DESCRIPTION
In issue #21, @sigvei highlighted that `s:project()` is evaluated on "line 0"
of the `autocommand` _even when not in a Bundler project_. This `throw`s and
manifests as 'E488: Trailing characters'.

This call was changed in ff2a956 consistent with  @bpinto's comment.

Introducing and calling `s:QuickFixCmdPostMake()` prevents this evaluation.

```
autocommand call s:QuickFixCmdPostMake()
line 0: call s:QuickFixCmdPostMake()
calling function <SNR>68_QuickFixCmdPostMake()
line 1:   if &makeprg =~# '^bundle' && exists('b:bundler_root')
line 2:     call s:pop_command()
line 3:     call s:project().paths('refresh')
line 4:   endif
function <SNR>68_QuickFixCmdPostMake returning #0
```
