### PR TITLE
Removes trailing slash on bundle_path

### DIFF
--- a/plugin/bundler.vim
+++ b/plugin/bundler.vim
@@ -289,7 +289,7 @@ function! s:project_paths(...) dict abort
     for config in [expand('~/.bundle/config'), self.path('.bundle/config')]
       if filereadable(config)
         let body = join(readfile(config), "\n")
-        let bundle_path = matchstr(body, "\\C\\<BUNDLE_PATH: '\\=\\zs[^\n']*")
+        let bundle_path = substitute(matchstr(body, "\\C\\<BUNDLE_PATH: '\\=\\zs[^\n']*"), '/$', '', '')
         if !empty(bundle_path)
           if body =~# '\C\<BUNDLE_DISABLE_SHARED_GEMS:'
             let gem_paths = [self.path(bundle_path, 'ruby', abi_version)]


### PR DESCRIPTION
There seems to be some kind of conflict with bufkill.vim, triggered by
doing something like:
- "mvim ." in some project
- :Btabedit somegem
- :bd: or :q or anything that kills the window

This only happens with locally bundled gems,
BUNDLE_DISABLE_SHARED_GEMS set, and the BUNDLE_PATH ends with a /, so
chop it off if it's there
