### PR TITLE
Fix shell-escaping of Ruby expressions.

### DIFF
--- a/plugin/bundler.vim
+++ b/plugin/bundler.vim
@@ -334,10 +334,10 @@ function! s:project_paths(...) dict abort
       exe chdir s:fnameescape(self.path())
 
       if len(gem_paths) == 0
-        let gem_paths = split(system(prefix.'ruby -rubygems -e "print Gem.path.join(%(;))"'), ';')
+        let gem_paths = split(system(prefix.'ruby -rubygems -e '.s:shellesc('print Gem.path.join(%(;))')), ';')
       endif
 
-      let abi_version = system('ruby -rrbconfig -e "print RbConfig::CONFIG[\"ruby_version\"]"')
+      let abi_version = system('ruby -rrbconfig -e '.s:shellesc('print RbConfig::CONFIG["ruby_version"]'))
       exe chdir s:fnameescape(cwd)
     finally
       exe chdir s:fnameescape(cwd)


### PR DESCRIPTION
I’ve been using C-Shell since I was a kid, a choice I inherited from my mom. Unfortunately, C-Shell does not support \" inside "", which is both bogus and sad. =(