### PR TITLE
Avoid running ruby twice

### DIFF
--- a/plugin/bundler.vim
+++ b/plugin/bundler.vim
@@ -360,10 +360,14 @@ function! s:project_paths(...) dict abort
       exe chdir s:fnameescape(self.path())
 
       if len(gem_paths) == 0
-        let gem_paths = split(system(prefix.'ruby -rrubygems -e '.s:shellesc('print Gem.path.join(%(;))')), ';')
+        let gem_paths = split(system(prefix.'ruby -rrbconfig -rrubygems -e '.s:shellesc('print(([RbConfig::CONFIG["ruby_version"]] + Gem.path).join(%(;)))')), ';')
+
+        let abi_version = gem_paths[0]
+        let gem_paths = gem_paths[1:]
+      else
+        let abi_version = system('ruby -rrbconfig -e '.s:shellesc('print RbConfig::CONFIG["ruby_version"]'))
       endif
 
-      let abi_version = system('ruby -rrbconfig -e '.s:shellesc('print RbConfig::CONFIG["ruby_version"]'))
       exe chdir s:fnameescape(cwd)
     finally
       exe chdir s:fnameescape(cwd)


### PR DESCRIPTION
Related to #38, but not a real fix.

The fork itself isn't slow, but with bundler activated etc, it can add up.

For me in a largish bundlery project, each of these (MRI) ruby invocations is about 0.7 seconds with hot caches (and an SSD). This doesn't help the first run on a cold start, which I think is when it actually feels slow, but it's still some gain. 🤷‍♂️ 