### PR TITLE
Fix gem_paths lost

### DIFF
--- a/plugin/bundler.vim
+++ b/plugin/bundler.vim
@@ -362,7 +362,7 @@ function! s:project_paths(...) dict abort
 
     " Explicitly setting $PATH means /etc/zshenv on OS X can't touch it.
     if executable('env')
-      let prefix = 'env PATH='.s:shellesc($PATH) . ' JRUBY_OPTS='.s:shellesc('--dev')
+      let prefix = 'env PATH='.s:shellesc($PATH) . ' JRUBY_OPTS='.s:shellesc('--dev') . ' '
     else
       let prefix = ''
     endif


### PR DESCRIPTION
<img width="517" alt="image" src="https://user-images.githubusercontent.com/41264693/166402174-5cd3886d-a0a9-4c3d-9310-188638393e3e.png">

I have upgraded vim-bundler recently. But I find it does not work anymore. Due to this [commit](https://github.com/tpope/vim-bundler/commit/6cd5302d22804889e0ab51296ccc4f401c89fa8e). It breaks gem_paths variable.